### PR TITLE
package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "genc": "bit-docs -dc",
     "genf": "bit-docs -df",
     "gh-pages": "gh-pages -d gh-pages",
-    "postinstall": "git submodule update --init",
+    "preinstall": "[ -f docs/modules/bit-docs/package.json ] || git submodule update --init",
     "pub": "npm run gh-pages",
     "see": "http-server gh-pages",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -31,21 +31,21 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "devDependencies": {
-    "bit-docs": "bit-docs/bit-docs",
+    "bit-docs": "bit-docs/bit-docs#file-pathed-deps",
     "gh-pages": "^0.12.0"
   },
   "bit-docs": {
     "dependencies": {
-      "bit-docs-dev": "bit-docs/bit-docs-dev",
-      "bit-docs-generate-html": "bit-docs/bit-docs-generate-html",
-      "bit-docs-glob-finder": "bit-docs/bit-docs-glob-finder",
-      "bit-docs-html-toc": "bit-docs/bit-docs-html-toc",
+      "bit-docs-dev": "file:docs/modules/bit-docs-dev",
+      "bit-docs-generate-html": "bit-docs/bit-docs-generate-html#file-pathed-deps",
+      "bit-docs-glob-finder": "file:docs/modules/bit-docs-glob-finder",
+      "bit-docs-html-toc": "file:docs/modules/bit-docs-html-toc",
       "bit-docs-js": "bit-docs/bit-docs-js#remove-depend",
-      "bit-docs-prettify": "bit-docs/bit-docs-prettify",
-      "bit-docs-html-highlight-line": "bit-docs/bit-docs-html-highlight-line",
-      "bit-docs-process-mustache": "bit-docs/bit-docs-process-mustache",
-      "bit-docs-tag-demo": "bit-docs/bit-docs-tag-demo",
-      "bit-docs-tag-sourceref": "bit-docs/bit-docs-tag-sourceref"
+      "bit-docs-prettify": "file:docs/modules/bit-docs-prettify",
+      "bit-docs-html-highlight-line": "file:docs/modules/bit-docs-html-highlight-line",
+      "bit-docs-process-mustache": "file:docs/modules/bit-docs-process-mustache",
+      "bit-docs-tag-demo": "file:docs/modules/bit-docs-tag-demo",
+      "bit-docs-tag-sourceref": "file:docs/modules/bit-docs-tag-sourceref"
     },
     "glob": {
       "pattern": "docs/**/*.{js,md,mustache}",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
         "**/*_test.js",
         "**/test_*.js",
         "**/test-*.md",
-        "**/test.js"
+        "**/test.js",
+        "**/node_modules/**/*"
       ]
     },
     "parent": "BitDocs",


### PR DESCRIPTION
See extended commit message details for more information on each commit.

Try it out:

```
git clone -b package-json-api https://github.com/bit-docs/bit-docs-website.git
cd bit-docs-website
npm install
npm run gen
npm run see
```

Because this `package.json` specifies the `#file-pathed-deps` branches for both [`bit-docs-generate-html`](https://github.com/bit-docs/bit-docs-generate-html/pull/20) and [`bit-docs/bit-docs`](https://github.com/bit-docs/bit-docs/pull/26), it is possible to edit the various submodules such as `bit-docs-prettify` and see the changes by simply running `npm run cache-bust && npm run gen` (as opposed to having to make a new release on npm or use complicated symlink scripts).

If you ever don't see your changes, try running `npm run genf` (takes longer; reinstalls everything).

A simple change you can test is to edit `docs/modules/bit-docs-prettify/prettify.less` to add some `background-color` to the `body`:

```
body {
  background-color: #eee;
}
```

This will be especially useful for websites that have their own "theme" plugin.

Note that submodules will only be updated once upon initial `npm install` because of the `-f test` in the `preinstall` command:

```
"preinstall": "[ -f docs/modules/bit-docs/package.json ] || git submodule update --init"
```

This is done because as you edit submodules they have the unfortunate side effect of throwing error if changes would be overwritten by `git submodule update` which also can move away from the changes you just made in the working directory (something you wouldn't want to happen upon running `npm install` a second or third time). The `update` in the initial `git submodule update --init` is needed because `git submodule init` doesn't actually clone things down initially, it just registers the `.gitmodules` file, so this all is necessary. This shows the caveat of using git submodules in the fact that they are rather hard to work with if you're unfamiliar.

The nice thing about git submodules is that if someone makes a PR with a docs change to for instance `bit-docs-prettify`, they could also submit a PR to `bit-docs-website` updating the `hash` that the submodule is pointing to. I also like how GitHub makes it obvious that [`docs/modules`](https://github.com/bit-docs/bit-docs-website/tree/1e05af57776b5faea8d154e787bc7005be9a9257/docs/modules) is meant to be a bunch of sub-repos like "bit-docs-prettify @ 114e4c9" that is also a link to that repo.

There's also git-subtree but that might be even more rare and hard to understand for people.

For some teams, a simple nodejs or bash script that clones the needed git repos into directories that are `.gitignored` upon initial `npm install` might be the best option.

Any of these options are better than the current `npm install` paradigm which has the pitfall of not being able to make changes, immediately test locally, and then commit (unlike the previously mentioned options that integrate with source control) — You could do something like `npm install ../path/to/previously/cloned/subrepo` but you'll have to do that for each and every plugin or documentation repo you want to work on, and it's manual setup that can be nicely baked-in like with the previously mentioned options.